### PR TITLE
fix(types): re-export types with import type/export type

### DIFF
--- a/packages/forms/src/types.ts
+++ b/packages/forms/src/types.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import {
+import type {
   IsEqual,
   FormState,
   FieldState,
@@ -9,9 +9,9 @@ import {
   FieldValidator,
   Unsubscribe,
 } from 'final-form';
-import { Mutators } from 'final-form-arrays';
+import type { Mutators } from 'final-form-arrays';
 
-export {
+export type {
   IsEqual,
   FormState,
   FieldState,

--- a/packages/forms/test/index.test.ts
+++ b/packages/forms/test/index.test.ts
@@ -20,14 +20,6 @@ describe('forms', () => {
       'Switch',
       'TextArea',
       'ToggleButtonController',
-      'IsEqual',
-      'FormState',
-      'FieldState',
-      'FieldSubscriber',
-      'FieldSubscription',
-      'FieldValidator',
-      'Unsubscribe',
-      'Mutators',
     ]);
   });
 });


### PR DESCRIPTION
**What**: Fix final-form re-exported types.

**Why**: to use this package without errors

**How**: https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#type-only-imports-exports