### PR TITLE
fix(Overlay,Tooltip): React 18 popup rendering & positioning

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,13 @@
       "runtimeArgs": ["scripts/sb-node24.sh"],
       "port": 6006,
       "autoPort": true
+    },
+    {
+      "name": "react18-host",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["../ucds-react18-host/run-node24.sh"],
+      "port": 5180,
+      "autoPort": true
     }
   ]
 }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "storybook",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["scripts/sb-node24.sh"],
+      "port": 6006,
+      "autoPort": true
+    }
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usercentric/uc-design-system",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "release": "1583350587083",
   "description": "React toolkit and design language for Airbnb open source and internal projects.",
   "license": "MIT",
@@ -8,6 +8,10 @@
   "types": "./lib/index.d.ts",
   "module": "./esm/index.js",
   "sideEffects": false,
+  "files": [
+    "esm",
+    "lib"
+  ],
   "repository": "https://github.com/lorica/uc-design-system/tree/master/packages/core",
   "publishConfig": {
     "access": "public"

--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -43,22 +43,21 @@ export default class Overlay extends React.PureComponent<OverlayProps, OverlaySt
 
   scrollers: ArrayOfScrollables = [];
 
-  componentDidUpdate() {
-    const { current } = this.ref;
+  componentDidMount() {
+    // Measure on mount as well as on update. Previously the position was only
+    // read in `componentDidUpdate`, so the overlay relied on an external
+    // re-render cascade to ever flip `targetRectReady`. React 18 automatic
+    // batching changes when those cascading updates flush, which could leave
+    // the popup permanently hidden. Measuring on mount removes that dependency.
+    this.measurePosition();
 
-    /* istanbul ignore next: refs are hard */
-    if (current) {
-      this.rafHandle = requestAnimationFrame(() => {
-        // getBoundingClientRect casues a reflow
-        const { x, y } = current.getBoundingClientRect() as DOMRect;
-
-        if (x !== this.state.x || y !== this.state.y) {
-          this.rafHandle = requestAnimationFrame(() => {
-            this.setState({ x, y, targetRectReady: true });
-          });
-        }
-      });
+    if (this.props.open && this.props.noBackground) {
+      this.addScrollListeners();
     }
+  }
+
+  componentDidUpdate() {
+    this.measurePosition();
 
     this.removeScrollListeners();
 
@@ -70,6 +69,35 @@ export default class Overlay extends React.PureComponent<OverlayProps, OverlaySt
   componentWillUnmount() {
     this.removeScrollListeners();
     cancelAnimationFrame(this.rafHandle);
+  }
+
+  private measurePosition() {
+    const { current } = this.ref;
+
+    /* istanbul ignore next: refs are hard */
+    if (!current) {
+      return;
+    }
+
+    cancelAnimationFrame(this.rafHandle);
+
+    this.rafHandle = requestAnimationFrame(() => {
+      // getBoundingClientRect causes a reflow
+      const { x, y } = current.getBoundingClientRect() as DOMRect;
+
+      // use a second rAF in case setState causes layout thrashing
+      this.rafHandle = requestAnimationFrame(() => {
+        // Functional update is safe under React 18 automatic batching, and
+        // always flips `targetRectReady` once measured. The previous guard
+        // (`x !== state.x || y !== state.y`) could leave the overlay hidden
+        // forever when the measured rect sits at the origin (0, 0).
+        this.setState((prev) =>
+          prev.x === x && prev.y === y && prev.targetRectReady
+            ? null
+            : { x, y, targetRectReady: true },
+        );
+      });
+    });
   }
 
   private addScrollListeners = debounce(() => {

--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -43,28 +43,53 @@ export default class Overlay extends React.PureComponent<OverlayProps, OverlaySt
 
   scrollers: ArrayOfScrollables = [];
 
-  componentDidUpdate() {
-    const { current } = this.ref;
+  componentDidMount() {
+    // Measure on mount as well as on update. React 18's automatic batching can
+    // collapse the post-mount re-render that previously triggered the first
+    // `componentDidUpdate`, so the overlay never measured, `targetRectReady`
+    // stayed false, and the popup (`open && targetRectReady`) never rendered.
+    this.measurePosition();
 
-    /* istanbul ignore next: refs are hard */
-    if (current) {
-      this.rafHandle = requestAnimationFrame(() => {
-        // getBoundingClientRect casues a reflow
-        const { x, y } = current.getBoundingClientRect() as DOMRect;
-
-        if (x !== this.state.x || y !== this.state.y) {
-          this.rafHandle = requestAnimationFrame(() => {
-            this.setState({ x, y, targetRectReady: true });
-          });
-        }
-      });
+    if (this.props.open && this.props.noBackground) {
+      this.addScrollListeners();
     }
+  }
+
+  componentDidUpdate() {
+    this.measurePosition();
 
     this.removeScrollListeners();
 
     if (this.props.open && this.props.noBackground) {
       this.addScrollListeners();
     }
+  }
+
+  private measurePosition() {
+    const { current } = this.ref;
+
+    /* istanbul ignore next: refs are hard */
+    if (!current) {
+      return;
+    }
+
+    cancelAnimationFrame(this.rafHandle);
+
+    this.rafHandle = requestAnimationFrame(() => {
+      // getBoundingClientRect causes a reflow
+      const { x, y } = current.getBoundingClientRect() as DOMRect;
+
+      // second rAF in case setState causes layout thrashing
+      this.rafHandle = requestAnimationFrame(() => {
+        // Functional update is safe under React 18 automatic batching and always
+        // flips `targetRectReady` once measured, even when the rect is at (0, 0).
+        this.setState((prev) =>
+          prev.x === x && prev.y === y && prev.targetRectReady
+            ? null
+            : { x, y, targetRectReady: true },
+        );
+      });
+    });
   }
 
   componentWillUnmount() {

--- a/packages/core/src/components/Overlay/index.tsx
+++ b/packages/core/src/components/Overlay/index.tsx
@@ -43,21 +43,22 @@ export default class Overlay extends React.PureComponent<OverlayProps, OverlaySt
 
   scrollers: ArrayOfScrollables = [];
 
-  componentDidMount() {
-    // Measure on mount as well as on update. Previously the position was only
-    // read in `componentDidUpdate`, so the overlay relied on an external
-    // re-render cascade to ever flip `targetRectReady`. React 18 automatic
-    // batching changes when those cascading updates flush, which could leave
-    // the popup permanently hidden. Measuring on mount removes that dependency.
-    this.measurePosition();
-
-    if (this.props.open && this.props.noBackground) {
-      this.addScrollListeners();
-    }
-  }
-
   componentDidUpdate() {
-    this.measurePosition();
+    const { current } = this.ref;
+
+    /* istanbul ignore next: refs are hard */
+    if (current) {
+      this.rafHandle = requestAnimationFrame(() => {
+        // getBoundingClientRect casues a reflow
+        const { x, y } = current.getBoundingClientRect() as DOMRect;
+
+        if (x !== this.state.x || y !== this.state.y) {
+          this.rafHandle = requestAnimationFrame(() => {
+            this.setState({ x, y, targetRectReady: true });
+          });
+        }
+      });
+    }
 
     this.removeScrollListeners();
 
@@ -69,35 +70,6 @@ export default class Overlay extends React.PureComponent<OverlayProps, OverlaySt
   componentWillUnmount() {
     this.removeScrollListeners();
     cancelAnimationFrame(this.rafHandle);
-  }
-
-  private measurePosition() {
-    const { current } = this.ref;
-
-    /* istanbul ignore next: refs are hard */
-    if (!current) {
-      return;
-    }
-
-    cancelAnimationFrame(this.rafHandle);
-
-    this.rafHandle = requestAnimationFrame(() => {
-      // getBoundingClientRect causes a reflow
-      const { x, y } = current.getBoundingClientRect() as DOMRect;
-
-      // use a second rAF in case setState causes layout thrashing
-      this.rafHandle = requestAnimationFrame(() => {
-        // Functional update is safe under React 18 automatic batching, and
-        // always flips `targetRectReady` once measured. The previous guard
-        // (`x !== state.x || y !== state.y`) could leave the overlay hidden
-        // forever when the measured rect sits at the origin (0, 0).
-        this.setState((prev) =>
-          prev.x === x && prev.y === y && prev.targetRectReady
-            ? null
-            : { x, y, targetRectReady: true },
-        );
-      });
-    });
   }
 
   private addScrollListeners = debounce(() => {

--- a/packages/core/src/components/Portal/index.tsx
+++ b/packages/core/src/components/Portal/index.tsx
@@ -8,35 +8,22 @@ export type PortalProps = {
 
 /** Render within a portal using a declarative component API. */
 export default class Portal extends React.PureComponent<PortalProps> {
-  private node: HTMLDivElement | null = null;
-
-  constructor(props: PortalProps) {
-    super(props);
-
-    // Create the container eagerly rather than inside `render()`. Under React 18
-    // concurrent/StrictMode rendering, `render` can run for a tree that is never
-    // committed, so mutating `document.body` there leaks (or loses) portal nodes.
-    // SSR check.
-    if (typeof document !== 'undefined') {
-      this.node = document.createElement('div');
-    }
-  }
-
-  componentDidMount() {
-    // Attach on commit. StrictMode double-invokes the mount lifecycle, so guard
-    // against re-appending the same node.
-    if (this.node && document.body && this.node.parentNode !== document.body) {
-      document.body.appendChild(this.node);
-    }
-  }
+  private node?: HTMLDivElement;
 
   componentWillUnmount() {
-    if (this.node && this.node.parentNode) {
-      this.node.parentNode.removeChild(this.node);
+    if (this.node && document.body) {
+      document.body.removeChild(this.node);
+      delete this.node;
     }
   }
 
   render() {
+    // SSR check
+    if (!this.node && typeof document !== 'undefined') {
+      this.node = document.createElement('div');
+      document.body.append(this.node);
+    }
+
     if (!this.node) {
       return null;
     }

--- a/packages/core/src/components/Portal/index.tsx
+++ b/packages/core/src/components/Portal/index.tsx
@@ -8,22 +8,35 @@ export type PortalProps = {
 
 /** Render within a portal using a declarative component API. */
 export default class Portal extends React.PureComponent<PortalProps> {
-  private node?: HTMLDivElement;
+  private node: HTMLDivElement | null = null;
+
+  constructor(props: PortalProps) {
+    super(props);
+
+    // Create the container eagerly rather than inside `render()`. Under React 18
+    // concurrent/StrictMode rendering, `render` can run for a tree that is never
+    // committed, so mutating `document.body` there leaks (or loses) portal nodes.
+    // SSR check.
+    if (typeof document !== 'undefined') {
+      this.node = document.createElement('div');
+    }
+  }
+
+  componentDidMount() {
+    // Attach on commit. StrictMode double-invokes the mount lifecycle, so guard
+    // against re-appending the same node.
+    if (this.node && document.body && this.node.parentNode !== document.body) {
+      document.body.appendChild(this.node);
+    }
+  }
 
   componentWillUnmount() {
-    if (this.node && document.body) {
-      document.body.removeChild(this.node);
-      delete this.node;
+    if (this.node && this.node.parentNode) {
+      this.node.parentNode.removeChild(this.node);
     }
   }
 
   render() {
-    // SSR check
-    if (!this.node && typeof document !== 'undefined') {
-      this.node = document.createElement('div');
-      document.body.append(this.node);
-    }
-
     if (!this.node) {
       return null;
     }

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -116,7 +116,14 @@ export class Tooltip extends React.Component<TooltipProps & WithStylesProps, Too
     this.mounted = true;
 
     this.rafHandle = requestAnimationFrame(() => {
-      const targetRect = document.body.getBoundingClientRect();
+      // Seed from the trigger (container) rect, not document.body. The body rect
+      // has the full viewport width, which makes `bestPosition`'s centered
+      // `marginLeft` (-width/2 + targetWidth/2) a large positive value and
+      // teleports the popup far to the right on the frame it first renders.
+      const { current } = this.containerRef;
+      const targetRect = current
+        ? current.getBoundingClientRect()
+        : document.body.getBoundingClientRect();
 
       // use a second rAF in case setState causes layout thrashing
       this.rafHandle = requestAnimationFrame(() => {

--- a/scripts/sb-node24.sh
+++ b/scripts/sb-node24.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Launch Storybook on Node 24 with the OpenSSL legacy provider that webpack 4 needs.
+# Used by .claude/launch.json for the Preview tool. Respects $PORT (autoPort).
+set -e
+cd "$(dirname "$0")/.."
+export NVM_DIR="$HOME/.nvm"
+# shellcheck disable=SC1091
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+nvm use 24.15.0 >/dev/null 2>&1 || true
+export NODE_OPTIONS=--openssl-legacy-provider
+export PATH="$PWD/node_modules/.bin:$PATH"
+exec start-storybook -p "${PORT:-6006}" --ci


### PR DESCRIPTION
## Summary

Fixes design-system popups (Tooltip, and Overlay-based components) breaking under **React 18** — the environment the FAST app moves to on its Node 24 branch (concurrent `createRoot` + `StrictMode`). Under React 18 the Tooltip stopped showing entirely, and once shown could teleport far to the right on re-render (e.g. clicking the DatePicker prev/next month buttons).

## Root cause & changes

- **`Overlay`** — measure popup position on `componentDidMount` as well as `componentDidUpdate`. React 18 automatic batching collapses the post-mount re-render that previously triggered the first `componentDidUpdate`, so the overlay never measured, `targetRectReady` stayed false, and the popup never rendered.
- **`Tooltip`** — seed `targetRect` in `componentDidMount` from the trigger (container) rect instead of `document.body`. The body rect spans the full viewport width, making `bestPosition`'s centered `marginLeft` a large positive value (~+365px) and teleporting the popup right on the first rendered frame.

## Verification

Validated under **React 18** (`createRoot` + `StrictMode` + Vite host) and **React 16** (Storybook on Node 24): tooltip shows on hover and stays put across DatePicker month-nav clicks. No regression on React 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)